### PR TITLE
Bump system/luet to 0.9.18

### DIFF
--- a/packages/luet/definition.yaml
+++ b/packages/luet/definition.yaml
@@ -1,6 +1,6 @@
 category: "system"
 name: "luet"
-version: "0.9.17"
+version: "0.9.18"
 labels:
   github.repo: "luet"
   github.owner: "mudler"


### PR DESCRIPTION
git: where we dropped our trunks and all have masters