### PR TITLE
Bump system/luet to 0.9.19

### DIFF
--- a/packages/luet/definition.yaml
+++ b/packages/luet/definition.yaml
@@ -1,6 +1,6 @@
 category: "system"
 name: "luet"
-version: "0.9.18"
+version: "0.9.19"
 labels:
   github.repo: "luet"
   github.owner: "mudler"


### PR DESCRIPTION
Answer: Because Oct 31 = Dec 25