### PR TITLE
Bump system/luet-extensions to 0.9.17

### DIFF
--- a/packages/luet-extensions/collection.yaml
+++ b/packages/luet-extensions/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - category: "system"
     name: "luet-extensions"
     description: "Luet extensions package"
-    version: "0.9.16"
+    version: "0.9.17"
     live: false
     labels:
       github.repo: "extensions"


### PR DESCRIPTION
git-cherry-pick does not yield actual delicious cherries