### PR TITLE
Bump system/luet-migrate-entropy to 0.9.17

### DIFF
--- a/packages/luet-extensions/collection.yaml
+++ b/packages/luet-extensions/collection.yaml
@@ -22,7 +22,7 @@ packages:
     name: "luet-migrate-entropy"
     live: false
     description: "Luet Entropy migration package"
-    version: "0.9.16"
+    version: "0.9.17"
     labels:
       github.repo: "extensions"
       github.owner: "Luet-lab"


### PR DESCRIPTION
all your rebase are belong to us