### PR TITLE
Bump system/luet-extensions to 0.10.3

### DIFF
--- a/packages/luet-extensions/collection.yaml
+++ b/packages/luet-extensions/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - category: "system"
     name: "luet-extensions"
     description: "Luet extensions package"
-    version: "0.10.1"
+    version: "0.10.3"
     live: false
     labels:
       github.repo: "extensions"


### PR DESCRIPTION
git request-pull: only legal in Nevada.