### PR TITLE
Bump system/entities to 0.5.1

### DIFF
--- a/packages/entities/definition.yaml
+++ b/packages/entities/definition.yaml
@@ -1,6 +1,6 @@
 category: "system"
 name: "entities"
-version: "0.5.0"
+version: "0.5.1"
 labels:
   github.repo: "entities"
   github.owner: "mudler"


### PR DESCRIPTION
Because, they don't know how to join tables.