### PR TITLE
Bump system/luet-devkit to 0.10.8

### DIFF
--- a/packages/luet-extensions/collection.yaml
+++ b/packages/luet-extensions/collection.yaml
@@ -11,7 +11,7 @@ packages:
   - category: "system"
     name: "luet-devkit"
     description: "Luet devkit package"
-    version: "0.10.7"
+    version: "0.10.8"
     live: false
     labels:
       github.repo: "extensions"


### PR DESCRIPTION
git-clone has nothing to do with reproduction. So stop that.