### PR TITLE
Bump system/luet-migrate-emerge to 0.11.3

### DIFF
--- a/packages/luet-extensions/collection.yaml
+++ b/packages/luet-extensions/collection.yaml
@@ -22,7 +22,7 @@ packages:
     name: "luet-migrate-emerge"
     live: false
     description: "Luet Emerge migration package"
-    version: "0.11.2"
+    version: "0.11.3"
     labels:
       github.repo: "extensions"
       github.owner: "Luet-lab"


### PR DESCRIPTION
git-stash: The sock drawer of version control