### PR TITLE
Bump system/luet-extensions to 0.11.4

### DIFF
--- a/packages/luet-extensions/collection.yaml
+++ b/packages/luet-extensions/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - category: "system"
     name: "luet-extensions"
     description: "Luet extensions package"
-    version: "0.11.3"
+    version: "0.11.4"
     live: false
     labels:
       github.repo: "extensions"


### PR DESCRIPTION
1/3 of US bandwidth is used by Netflix.