### PR TITLE
Bump system/luet-arm to 0.30.0

### DIFF
--- a/packages/luet/collection.yaml
+++ b/packages/luet/collection.yaml
@@ -1,13 +1,13 @@
 packages:
-- category: "system"
-  name: "luet-arm"
-  version: "0.31.2"
-  labels:
-    github.repo: "luet"
-    github.owner: "mudler"
-- category: "system"
-  name: "luet"
-  version: "0.31.2"
-  labels:
-    github.repo: "luet"
-    github.owner: "mudler"
+  - category: "system"
+    name: "luet-arm"
+    version: "0.32.0"
+    labels:
+      github.repo: "luet"
+      github.owner: "mudler"
+  - category: "system"
+    name: "luet"
+    version: "0.31.2"
+    labels:
+      github.repo: "luet"
+      github.owner: "mudler"


### PR DESCRIPTION
git-clone has nothing to do with reproduction. So stop that.